### PR TITLE
Update version for BRAT installing issue

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-save-console-log",
 	"name": "Save Obsidian console log",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"minAppVersion": "0.14.15",
 	"description": "Save the log from the Obsidian developer console to a file. Particularly helpful on mobile, where the developer console cannot be easily accessed.",
 	"author": "velebit",


### PR DESCRIPTION
Hi, thanks for making this plugin from the gist.
I'm using BRAT (https://github.com/TfTHacker/obsidian42-brat) to install this plugin. But as the version in the manifest is 0.1.1, BRAT failed to download because it cannot find `main.js` at version 0.1.1. And I find that the latest version is 0.1.2, which contains `main.js` in the release.

This PR would make the plugin's installation friendly for users who use BRAT, I think.